### PR TITLE
refactor: convert to simple WebSocket proxy pattern

### DIFF
--- a/deepgram.toml
+++ b/deepgram.toml
@@ -1,11 +1,12 @@
 [meta]
-title = "Node Live Transcription Starter"
+title = "Node Live Transcription"
 description = "Get started using Deepgram's Live Transcription with this Node demo app"
 author = "Deepgram DX Team <devrel@deepgram.com> (https://developers.deepgram.com)"
 useCase = "Live STT"
 language = "JavaScript"
 framework = "Node"
 sdk = "4.11.2"
+repository = "https://github.com/deepgram-starters/node-live-transcription"
 
 [pre-build]
 command = "pnpm run install:all"

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
   },
   "homepage": "https://github.com/deepgram-starters/node-live-transcription#readme",
   "dependencies": {
-    "@deepgram/sdk": "4.11.2",
     "dotenv": "16.4.7",
     "express": "5.2.1",
     "http-proxy-middleware": "3.0.5",
     "npm-run-all": "4.1.5",
+    "toml": "3.0.0",
     "ws": "8.18.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@deepgram/sdk':
-        specifier: 4.11.2
-        version: 4.11.2
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
@@ -23,6 +20,9 @@ importers:
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
+      toml:
+        specifier: 3.0.0
+        version: 3.0.0
       ws:
         specifier: 8.18.0
         version: 8.18.0
@@ -33,19 +33,8 @@ importers:
 
 packages:
 
-  '@deepgram/captions@1.2.0':
-    resolution: {integrity: sha512-8B1C/oTxTxyHlSFubAhNRgCbQ2SQ5wwvtlByn8sDYZvdDtdn/VE2yEPZ4BvUnrKWmsbTQY6/ooLV+9Ka2qmDSQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@deepgram/sdk@4.11.2':
-    resolution: {integrity: sha512-lKGxuXxlSixC8bB0BnzmIpbVjUSgYtz17cqvrgv0ZjmazgUPkuUj9egQPj6k+fbPX8wRzWEqlhrL/DXlXqeDXA==}
-    engines: {node: '>=18.0.0'}
-
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@25.0.0':
     resolution: {integrity: sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==}
@@ -145,9 +134,6 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cross-fetch@3.2.0:
-    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
-
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -164,9 +150,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -175,10 +158,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -247,10 +226,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -559,15 +534,6 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   nodemon@3.1.10:
     resolution: {integrity: sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==}
     engines: {node: '>=10'}
@@ -829,12 +795,12 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   touch@3.1.1:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -863,9 +829,6 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -879,12 +842,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -923,30 +880,9 @@ packages:
 
 snapshots:
 
-  '@deepgram/captions@1.2.0':
-    dependencies:
-      dayjs: 1.11.19
-
-  '@deepgram/sdk@4.11.2':
-    dependencies:
-      '@deepgram/captions': 1.2.0
-      '@types/node': 18.19.130
-      cross-fetch: 3.2.0
-      deepmerge: 4.3.1
-      events: 3.3.0
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
-
   '@types/http-proxy@1.17.17':
     dependencies:
       '@types/node': 25.0.0
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@25.0.0':
     dependencies:
@@ -1067,12 +1003,6 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cross-fetch@3.2.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -1099,15 +1029,11 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dayjs@1.11.19: {}
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
-
-  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -1224,8 +1150,6 @@ snapshots:
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
-
-  events@3.3.0: {}
 
   express@5.2.1:
     dependencies:
@@ -1569,10 +1493,6 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   nodemon@3.1.10:
     dependencies:
       chokidar: 3.6.0
@@ -1906,9 +1826,9 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  touch@3.1.1: {}
+  toml@3.0.0: {}
 
-  tr46@0.0.3: {}
+  touch@3.1.1: {}
 
   type-is@2.0.1:
     dependencies:
@@ -1958,8 +1878,6 @@ snapshots:
 
   undefsafe@2.0.5: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@7.16.0: {}
 
   unpipe@1.0.0: {}
@@ -1970,13 +1888,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   vary@1.1.2: {}
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/server.js
+++ b/server.js
@@ -1,11 +1,19 @@
+/**
+ * Node Live Transcription Starter - Backend Server
+ *
+ * Simple WebSocket proxy to Deepgram's Live Transcription API.
+ * Forwards all messages (JSON and binary) bidirectionally between client and Deepgram.
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
 import express from 'express';
-import { WebSocketServer } from 'ws';
 import { createServer } from 'http';
-import { createClient, LiveTranscriptionEvents } from '@deepgram/sdk';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import toml from 'toml';
 
 // Load environment variables
 dotenv.config();
@@ -21,19 +29,15 @@ if (!process.env.DEEPGRAM_API_KEY) {
   process.exit(1);
 }
 
+// Configuration
 const CONFIG = {
+  deepgramApiKey: process.env.DEEPGRAM_API_KEY,
+  deepgramSttUrl: 'wss://api.deepgram.com/v1/listen',
   port: process.env.PORT || 8080,
   host: process.env.HOST || '0.0.0.0',
   vitePort: process.env.VITE_PORT || 5173,
   isDevelopment: process.env.NODE_ENV === 'development',
 };
-
-// Validate API Key exists
-if (!process.env.DEEPGRAM_API_KEY) {
-  console.error('ERROR: DEEPGRAM_API_KEY environment variable is required');
-  console.error('Please copy sample.env to .env and add your API key');
-  process.exit(1);
-}
 
 const app = express();
 const server = createServer(app);
@@ -46,179 +50,135 @@ const activeConnections = new Set();
 let viteProxy = null;
 
 /**
- * Handles new WebSocket connections
+ * Metadata endpoint - returns application metadata from deepgram.toml
+ */
+app.get('/metadata', (req, res) => {
+  try {
+    const tomlPath = path.join(__dirname, 'deepgram.toml');
+    const tomlContent = fs.readFileSync(tomlPath, 'utf-8');
+    const config = toml.parse(tomlContent);
+
+    if (!config.meta) {
+      return res.status(500).json({
+        error: 'INTERNAL_SERVER_ERROR',
+        message: 'Missing [meta] section in deepgram.toml'
+      });
+    }
+
+    res.json(config.meta);
+  } catch (error) {
+    console.error('Error reading metadata:', error);
+    res.status(500).json({
+      error: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to read metadata from deepgram.toml'
+    });
+  }
+});
+
+/**
+ * WebSocket proxy handler
+ * Forwards all messages bidirectionally between client and Deepgram
  */
 wss.on('connection', async (clientWs, request) => {
-  console.log('Client connected to /live-stt/stream');
+  console.log('Client connected to /stt/stream');
   activeConnections.add(clientWs);
 
-  // Parse query parameters
+  // Parse query parameters from client request
   const url = new URL(request.url, `http://${request.headers.host}`);
   const model = url.searchParams.get('model') || 'nova-3';
   const language = url.searchParams.get('language') || 'en';
+  const smart_format = url.searchParams.get('smart_format') || 'true';
+  const encoding = url.searchParams.get('encoding') || 'linear16';
+  const sample_rate = url.searchParams.get('sample_rate') || '16000';
+  const channels = url.searchParams.get('channels') || '1';
 
-  let deepgramConnection = null;
+  // Build Deepgram WebSocket URL with query parameters
+  const deepgramUrl = new URL(CONFIG.deepgramSttUrl);
+  deepgramUrl.searchParams.set('model', model);
+  deepgramUrl.searchParams.set('language', language);
+  deepgramUrl.searchParams.set('smart_format', smart_format);
+  deepgramUrl.searchParams.set('encoding', encoding);
+  deepgramUrl.searchParams.set('sample_rate', sample_rate);
+  deepgramUrl.searchParams.set('channels', channels);
 
-  // First try-catch: Create Deepgram connection
-  try {
-    const deepgram = createClient(process.env.DEEPGRAM_API_KEY);
+  console.log(`Connecting to Deepgram STT: model=${model}, language=${language}, encoding=${encoding}, sample_rate=${sample_rate}, channels=${channels}`);
 
-    deepgramConnection = deepgram.listen.live({
-      model,
-      language,
-      smart_format: true,
-    });
-  } catch (error) {
-    console.error('Error creating Deepgram connection:', error);
+  // Create WebSocket connection to Deepgram
+  const deepgramWs = new WebSocket(deepgramUrl.toString(), {
+    headers: {
+      'Authorization': `Token ${CONFIG.deepgramApiKey}`
+    }
+  });
 
-    // Send clear error to client
-    const errorResponse = {
-      error: {
-        type: 'ConnectionError',
-        code: 'DEEPGRAM_CONNECTION_FAILED',
-        message: 'Failed to establish connection to Deepgram. Please check your API key.',
-        details: {
-          reason: error.message,
-          hint: 'Verify DEEPGRAM_API_KEY is set correctly in .env'
-        }
-      }
-    };
+  let clientMessageCount = 0;
+  let deepgramMessageCount = 0;
 
-    clientWs.send(JSON.stringify(errorResponse));
-    clientWs.close(1011, 'Deepgram connection failed');
-    activeConnections.delete(clientWs);
-    return;
-  }
+  // Forward Deepgram messages to client
+  deepgramWs.on('message', (data, isBinary) => {
+    deepgramMessageCount++;
+    if (deepgramMessageCount % 10 === 0 || !isBinary) {
+      console.log(`← Deepgram message #${deepgramMessageCount} (binary: ${isBinary}, size: ${data.length})`);
+    }
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.send(data, { binary: isBinary });
+    }
+  });
 
-  let keepAlive;
+  // Forward client messages to Deepgram
+  clientWs.on('message', (data, isBinary) => {
+    clientMessageCount++;
+    if (clientMessageCount % 100 === 0 || !isBinary) {
+      console.log(`→ Client message #${clientMessageCount} (binary: ${isBinary}, size: ${data.byteLength || data.length})`);
+    }
+    if (deepgramWs.readyState === WebSocket.OPEN) {
+      deepgramWs.send(data, { binary: isBinary });
+    }
+  });
 
-  // Second try-catch: Set up audio streaming
-  try {
+  // Handle Deepgram connection open
+  deepgramWs.on('open', () => {
+    console.log('✓ Connected to Deepgram STT API');
+  });
 
-    // Set up Deepgram event listeners
-    deepgramConnection.on(LiveTranscriptionEvents.Open, () => {
-      console.log('Deepgram connection opened');
+  // Handle Deepgram errors
+  deepgramWs.on('error', (error) => {
+    console.error('Deepgram WebSocket error:', error);
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.close(1011, 'Deepgram connection error');
+    }
+  });
 
-      // Start keepalive
-      keepAlive = setInterval(() => {
-        if (deepgramConnection.getReadyState() === 1) {
-          deepgramConnection.keepAlive();
-        }
-      }, 10000);
-
-      // Notify client we're ready to receive audio
-      const readyMessage = {
-        type: 'Ready',
-        message: 'Ready to receive audio'
-      };
-      clientWs.send(JSON.stringify(readyMessage));
-    });
-
-    deepgramConnection.on(LiveTranscriptionEvents.Metadata, (data) => {
-      console.log('Deepgram metadata received');
-
-      // Pass through Deepgram's metadata to client
-      const metadata = {
-        type: 'Metadata',
-        request_id: data.request_id,
-        model_info: data.model_info,
-        created: data.created
-      };
-      clientWs.send(JSON.stringify(metadata));
-    });
-
-    deepgramConnection.on(LiveTranscriptionEvents.Transcript, (data) => {
-      // Extract transcript from Deepgram response
-      const transcript = data.channel?.alternatives?.[0]?.transcript || '';
-      const isFinal = data.is_final || false;
-      const speechFinal = data.speech_final || false;
-
-      if (transcript) {
-        const result = {
-          type: 'Results',
-          transcript,
-          is_final: isFinal,
-          speech_final: speechFinal,
-          confidence: data.channel?.alternatives?.[0]?.confidence,
-          words: data.channel?.alternatives?.[0]?.words || [],
-          duration: data.duration,
-          start: data.start,
-          metadata: {
-            model: model,
-            language: language
-          }
-        };
-
-        clientWs.send(JSON.stringify(result));
-      }
-    });
-
-    deepgramConnection.on(LiveTranscriptionEvents.Error, (error) => {
-      console.error('Deepgram error:', error);
-      const errorMessage = {
-        error: {
-          type: 'DeepgramError',
-          code: 'CONNECTION_FAILED',
-          message: error.message || 'Deepgram connection error',
-          details: error
-        }
-      };
-      clientWs.send(JSON.stringify(errorMessage));
-    });
-
-    deepgramConnection.on(LiveTranscriptionEvents.Close, () => {
-      console.log('Deepgram connection closed');
-      clearInterval(keepAlive);
-    });
-
-    // Listen for binary audio data from frontend and forward to Deepgram
-    clientWs.on('message', (data) => {
-      if (deepgramConnection && deepgramConnection.getReadyState() === 1) {
-        deepgramConnection.send(data);
-      }
-    });
-
-  } catch (error) {
-    console.error('Error setting up transcription:', error);
-
-    const errorMessage = {
-      error: {
-        type: 'ConnectionError',
-        code: 'CONNECTION_FAILED',
-        message: error.message
-      }
-    };
-
-    clientWs.send(JSON.stringify(errorMessage));
-    clientWs.close(1011, 'Setup error');
-    activeConnections.delete(clientWs);
-    return;
-  }
+  // Handle Deepgram connection close
+  deepgramWs.on('close', (code, reason) => {
+    console.log(`Deepgram connection closed: ${code} ${reason}`);
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.close(code, reason.toString());
+    }
+  });
 
   // Handle client disconnect
-  clientWs.on('close', () => {
-    console.log('Client disconnected');
-
-    // Clean up Deepgram connection
-    if (deepgramConnection) {
-      deepgramConnection.finish();
-      deepgramConnection.removeAllListeners();
+  clientWs.on('close', (code, reason) => {
+    console.log(`Client disconnected: ${code} ${reason}`);
+    if (deepgramWs.readyState === WebSocket.OPEN) {
+      deepgramWs.close(1000, 'Client disconnected');
     }
-
     activeConnections.delete(clientWs);
   });
 
+  // Handle client errors
   clientWs.on('error', (error) => {
     console.error('Client WebSocket error:', error);
+    if (deepgramWs.readyState === WebSocket.OPEN) {
+      deepgramWs.close(1011, 'Client error');
+    }
   });
 });
-
 
 /**
  * In development: Proxy all requests to Vite dev server for hot reload
  * In production: Serve pre-built static files from frontend/dist
  *
- * IMPORTANT: This MUST come AFTER your WebSocket routes to avoid conflicts
+ * IMPORTANT: This MUST come AFTER your API routes to avoid conflicts
  */
 if (CONFIG.isDevelopment) {
   console.log(`Development mode: Proxying to Vite dev server on port ${CONFIG.vitePort}`);
@@ -239,9 +199,9 @@ if (CONFIG.isDevelopment) {
 
     console.log(`WebSocket upgrade request for: ${pathname}`);
 
-    // Backend handles /live-stt/stream WebSocket connections directly
-    if (pathname === '/live-stt/stream') {
-      console.log('Backend handling /live-stt/stream WebSocket');
+    // Backend handles /stt/stream WebSocket connections directly
+    if (pathname === '/stt/stream') {
+      console.log('Backend handling /stt/stream WebSocket');
       wss.handleUpgrade(request, socket, head, (ws) => {
         wss.emit('connection', ws, request);
       });
@@ -259,6 +219,9 @@ if (CONFIG.isDevelopment) {
   app.use(express.static(distPath));
 }
 
+/**
+ * Graceful shutdown handler
+ */
 function gracefulShutdown(signal) {
   console.log(`\n${signal} signal received: starting graceful shutdown...`);
 
@@ -306,10 +269,11 @@ process.on('unhandledRejection', (reason, promise) => {
   gracefulShutdown('UNHANDLED_REJECTION');
 });
 
+// Start server
 server.listen(CONFIG.port, CONFIG.host, () => {
   console.log("\n" + "=".repeat(70));
   console.log(`🚀 Live STT Backend Server running at http://localhost:${CONFIG.port}`);
-  console.log(`📡 WebSocket endpoint: ws://localhost:${CONFIG.port}/live-stt/stream`);
+  console.log(`📡 WebSocket endpoint: ws://localhost:${CONFIG.port}/stt/stream`);
   if (CONFIG.isDevelopment) {
     console.log(`📡 Proxying frontend from Vite dev server on port ${CONFIG.vitePort}`);
     console.log(`\n⚠️  Open your browser to http://localhost:${CONFIG.port}`);


### PR DESCRIPTION
## Summary

Completely refactored the backend to use a simple bidirectional WebSocket proxy instead of the Deepgram SDK, matching the pattern used in node-voice-agent and node-live-text-to-speech.

This continues the work from #22 (port standardization) by completing the architectural refactoring.

### Key Changes

**Backend Architecture:**
- Removed `@deepgram/sdk` dependency in favor of direct WebSocket connection to Deepgram API
- Implemented transparent bidirectional message forwarding (both JSON and binary)
- Changed endpoint from `/live-stt/stream` to `/stt/stream` for consistency across starters
- Acts as a simple pass-through proxy without SDK abstraction

**Configuration & Metadata:**
- Added `/metadata` endpoint that reads from `deepgram.toml`
- Added `toml` package for configuration parsing
- Updated `deepgram.toml` with repository field for dynamic metadata

**Audio Format Handling:**
- Configurable audio format parameters (encoding, sample_rate, channels)
- Parameters are passed from frontend through query string to Deepgram
- Ensures proper format matching between browser AudioContext and Deepgram expectations

**Improvements:**
- Enhanced connection logging for debugging
- Better error handling and graceful shutdown
- Cleaner separation of concerns (proxy vs. SDK logic)
- Reduced bundle size by removing SDK dependency

### Frontend Integration

Updated frontend submodule to `feat/horizontal-three-column-microphone-ui` which includes:
- Three-column horizontal layout
- Microphone capture with Web Audio API
- Real-time transcription display

### Technical Details

The proxy forwards messages bidirectionally:
- **Client → Deepgram**: Binary audio chunks (Int16 PCM)
- **Deepgram → Client**: JSON transcription results and metadata

Audio format parameters flow:
1. Frontend detects AudioContext capabilities
2. Passes parameters via WebSocket query string
3. Backend forwards to Deepgram WebSocket URL
4. Ensures format compatibility throughout the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)